### PR TITLE
ajaxcontent: parse 'lecturers' array

### DIFF
--- a/js/ajaxcontent.js
+++ b/js/ajaxcontent.js
@@ -22,7 +22,7 @@ function loadVLAufzeichnung() {
           (e) => new Date(e.attributes.start) - new Date() < 4*7*24*60*60*1000
         )
         .map(
-          (e) => e.attributes.lecturer + ': ' +
+          (e) => e.attributes.lecturers.join(', ') + ': ' +
                  e.attributes.title    + ' (' +
                  (new Date(e.attributes.start)).toLocaleString()     + ' &ndash; ' +
                  (new Date(e.attributes.end))  .toLocaleTimeString() + ')'


### PR DESCRIPTION
This commit joins the defined lecturers Array to a human-readable String.

eLectures will slightly change the returned JSON schema for the
public_schedule service. The system allows for multiple lecturers per
lecture, so the returned data should reflect that properly.

Upstream will soon(tm) respond with the `lecturers` attribute, which is an
array of Strings with 0 or more members. The previous `lecturer` attribute
will be omitted.

~__ATTENTION: DO NOT MERGE THIS YET!__~
I will update this PR once this change has been introduced in production.